### PR TITLE
Implement scalable Contentful service

### DIFF
--- a/components/HomeContent.js
+++ b/components/HomeContent.js
@@ -14,7 +14,7 @@ import Loader from "./ui/Loader";
  * Componente controlador que decide qual view exibir (pública ou de aluno)
  * com base no status de autenticação do usuário.
  */
-export default function HomeContent({ heroImages }) {
+export default function HomeContent({ pageData, presentations }) {
   const { user } = useAuth();
   const [isMounted, setIsMounted] = useState(false);
 
@@ -32,6 +32,6 @@ export default function HomeContent({ heroImages }) {
   return user ? (
     <StudentDashboard user={user} />
   ) : (
-    <PublicLandingPage heroImages={heroImages} />
+    <PublicLandingPage pageData={pageData} presentations={presentations} />
   );
 }

--- a/components/public/PublicLandingPage.js
+++ b/components/public/PublicLandingPage.js
@@ -9,25 +9,28 @@ import HeroSection from "./HeroSection";
 // No futuro, você vai criar cada um destes como um componente separado
 // em sua própria pasta, assim como fizemos aqui.
 
-const SobreSection = () => (
+const SobreSection = ({ texto }) => (
   <section className="py-20 bg-white">
     <div className="container mx-auto px-6 text-center">
       <h2 className="text-4xl font-bold mb-6">Sobre o Grupo</h2>
       <p className="text-gray-600 max-w-2xl mx-auto">
-        Aqui virá a descrição do grupo Rakusai Taiko, sua história, filosofia e
-        paixão pela cultura japonesa.
+        <div dangerouslySetInnerHTML={{ __html: texto }} />
       </p>
     </div>
   </section>
 );
 
-const ApresentacoesSection = () => (
+const ApresentacoesSection = ({ presentations }) => (
   <section className="py-20 bg-gray-100">
     <div className="container mx-auto px-6 text-center">
       <h2 className="text-4xl font-bold mb-6">Próximas Apresentações</h2>
-      <p className="text-gray-600">
-        Aqui será exibida a lista de futuros eventos e apresentações.
-      </p>
+      <ul>
+        {presentations.map((event, index) => (
+          <li key={index}>
+            {event.title} - {new Date(event.date).toLocaleDateString()}
+          </li>
+        ))}
+      </ul>
     </div>
   </section>
 );
@@ -45,17 +48,22 @@ const ContatoSection = () => (
 
 // --- Componente Principal da Landing Page ---
 
-export default function PublicLandingPage({ heroImages }) {
-  // No futuro, você pode adicionar estados aqui se precisar
-  // gerenciar algo que afete múltiplas seções (ex: um tema claro/escuro).
+export default function PublicLandingPage({ pageData, presentations }) {
+  // Para pegar os dados do carrossel:
+  const carouselData = pageData?.homeCarrossel || {};
+
+  // Para pegar a descrição da seção "Sobre":
+  const aboutDescriptionHtml = pageData?.homeSobre?.description || "";
 
   return (
     <main>
-      <HeroSection images={heroImages} />
-      <SobreSection />
-      <ApresentacoesSection />
+      <HeroSection images={carouselData.images} />
+
+      <SobreSection texto={aboutDescriptionHtml} />
+      <ApresentacoesSection presentations={presentations} />
       <ContatoSection />
-      {/* Adicione outras seções como Galeria, etc., aqui */}
+
+      {/* ... e assim por diante para cada seção ... */}
     </main>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@commitlint/cli": "19.8.0",
         "@commitlint/config-conventional": "19.8.0",
+        "@contentful/rich-text-html-renderer": "^17.1.0",
         "@heroicons/react": "2.2.0",
         "@tailwindcss/postcss": "4.0.16",
         "async-retry": "1.3.3",
@@ -28,7 +29,7 @@
         "postcss": "8.5.3",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "swiper": "^11.2.10",
+        "swiper": "11.2.10",
         "swr": "2.3.3",
         "tailwind-scrollbar": "4.0.2",
         "tailwindcss": "4.0.16",
@@ -894,6 +895,29 @@
       "dependencies": {
         "@vercel/stega": "^0.1.2",
         "json-pointer": "^0.6.2"
+      }
+    },
+    "node_modules/@contentful/rich-text-html-renderer": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.1.0.tgz",
+      "integrity": "sha512-ALyLVFnZZNr5o7at/JuZk5Ve/AjLJfzPllTade66vYiev5J5wVVxHzESTQ3/0Xpg4dCeaB3JvM5YN/iEZoceyA==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.1.0",
+        "escape-html": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-html-renderer/node_modules/@contentful/rich-text-types": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.1.0.tgz",
+      "integrity": "sha512-L0rok1VoMUbtQPJefR0Oxr5z1ow9/ZDIvuNWu16VT4IVVOKkeL4sVsjNj08cCT3ON+HUUzbPWVzyTuyvee2TSg==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -5673,6 +5697,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -7877,6 +7906,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@commitlint/cli": "19.8.0",
     "@commitlint/config-conventional": "19.8.0",
+    "@contentful/rich-text-html-renderer": "^17.1.0",
     "@heroicons/react": "2.2.0",
     "@tailwindcss/postcss": "4.0.16",
     "async-retry": "1.3.3",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,16 @@
 import Head from "next/head";
 import HomeContent from "components/HomeContent";
 import { texts } from "src/utils/texts.js";
-import { fetchHeroCarouselImages } from "services/contentfulService.js"; // <<< IMPORTAR
+import {
+  fetchLandingPageData,
+  fetchUpcomingPresentations,
+} from "services/contentfulService.js";
 
 /**
  * Página inicial da aplicação
  */
-export default function Home({ heroImages }) {
-  // <<< RECEBE AS PROPS
+// A página agora recebe 'pageData' e 'presentations' como props
+export default function Home({ pageData, presentations }) {
   return (
     <>
       <Head>
@@ -16,24 +19,23 @@ export default function Home({ heroImages }) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
 
-      {/* O HomeContent agora não precisa mais do InitialLoading, 
-          pois a página só será exibida após os dados carregarem. 
-          Você pode passar as imagens para ele se a lógica de login mudar, 
-          ou diretamente para o PublicLandingPage dentro dele.
-      */}
-      <HomeContent heroImages={heroImages} />
+      {/* Passamos todos os dados para os componentes filhos */}
+      <HomeContent pageData={pageData} presentations={presentations} />
     </>
   );
 }
 
 // Função do Next.js para buscar dados estáticos na hora da build
 export async function getStaticProps() {
-  const heroImages = await fetchHeroCarouselImages();
+  // Chamamos as duas funções para buscar todos os dados necessários
+  const pageData = await fetchLandingPageData();
+  const presentations = await fetchUpcomingPresentations();
 
   return {
     props: {
-      heroImages, // Passa as imagens como props para o componente da página
+      pageData,
+      presentations,
     },
-    revalidate: 60, // Opcional: Regenera a página a cada 60s para buscar novas imagens
+    revalidate: 60, // Regenera a página a cada 60s para buscar novos dados
   };
 }


### PR DESCRIPTION
The previous contentfulService was hardcoded to fetch only a single
content type (hero carousel images). This commit refactors the entire
service to be scalable and support multiple content types for the
landing page.

Key Changes:

-  Introduced a generic `fetchLandingPageData` function that fetches all single-entry content types (About, Contact, etc.) in a single, optimized API call.
-  Created individual parser functions for each content type to sanitize and shape the data before it reaches the components.
-  Added a central configuration map (`SINGLE_ENTRY_CONFIG`) to make it easy to add new content types in the future.
-  Implemented a separate `fetchUpcomingPresentations` for handling multi-entry content types, with sorting by date.
- Added the `@contentful/rich-text-html-renderer` library to properly handle and render Rich Text fields as HTML.
- Updated `getStaticProps` in `pages/index.js` to use the new service and pass the structured `pageData` prop to child components.