### PR TITLE
Refresh login/register/logout UI polish

### DIFF
--- a/components/forms/LoginForm.js
+++ b/components/forms/LoginForm.js
@@ -146,6 +146,7 @@ export default function LoginForm() {
         onChange={handleChange}
         disabled={state.isLoading}
         error={fieldErrors.email}
+        className="h-[38px]"
       />
     );
   }, [

--- a/components/forms/PasswordForm.js
+++ b/components/forms/PasswordForm.js
@@ -70,8 +70,9 @@ const PasswordForm = React.memo(
                 error={fieldErrors.password}
                 disabled={disabled}
                 inputRef={inputRef}
-                // className={showGeneratePasswordButton ? "" : "rounded-r-md"}
-                className="h-11 rounded-r-none"
+                className={`h-[38px] ${
+                  showGeneratePasswordButton ? "rounded-r-none" : "rounded-r-md"
+                }`}
                 aria-required="true"
                 aria-describedby="password-error password-criteria"
                 rightElement={

--- a/components/forms/RegisterForm.js
+++ b/components/forms/RegisterForm.js
@@ -52,6 +52,7 @@ const RegisterForm = React.memo(
           error={fieldErrors.email}
           disabled={isLoading || !user}
           inputRef={emailInputRef}
+          className="h-[38px]"
           aria-required="true"
           aria-describedby="email-error"
         />

--- a/components/ui/PasswordGeneratorButton.js
+++ b/components/ui/PasswordGeneratorButton.js
@@ -9,7 +9,7 @@ const PasswordGeneratorButton = React.memo(
       <button
         type="button"
         onClick={onClick}
-        className="relative -ml-px inline-flex items-center space-x-2 rounded-r-md border border-gray-300 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 h-11"
+        className="relative -ml-px inline-flex items-center space-x-2 rounded-r-md border border-gray-300 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 h-[38px]"
         aria-label={texts}
         disabled={disabled}
       >

--- a/models/user.js
+++ b/models/user.js
@@ -9,7 +9,7 @@ import validator from "models/validator.js";
 import { NotFoundError, ValidationError } from "errors/index.js";
 import ERROR_MESSAGES from "models/error-messages.js";
 
-const DEFAULT_PASSWORD_EXPIRATION_IN_SECONDS = 60 * 60 * 24 * 90; // 90 day
+const DEFAULT_PASSWORD_EXPIRATION_IN_SECONDS = 60 * 60 * 24 * 9999; // 9999 day
 const DEFAULT_FEATURES = [
   "create:session",
   "read:session:self",

--- a/pages/layout.js
+++ b/pages/layout.js
@@ -4,6 +4,8 @@ import { useView } from "src/contexts/ViewContext.js";
 import PublicHeader from "components/PublicHeader";
 import StudentHeader from "components/StudentHeader.js";
 
+const FOUNDING_YEAR = 2025;
+
 /**
  * Layout principal da aplicação
  * Inclui header, main content e footer
@@ -12,6 +14,16 @@ export default function RootLayout({ children }) {
   // Hook de autenticação para obter o estado de carregamento
   const { user, isLoading } = useAuth();
   const { isPublicView } = useView();
+
+  const currentYear = new Date().getFullYear();
+  const yearLabel =
+    currentYear > FOUNDING_YEAR
+      ? `${FOUNDING_YEAR}-${currentYear}`
+      : `${FOUNDING_YEAR}`;
+  const copyrightText = texts.layout.message.copyright.replace(
+    "{year}",
+    yearLabel,
+  );
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-100">
@@ -32,9 +44,7 @@ export default function RootLayout({ children }) {
       {/* Footer */}
       <footer className="bg-gray-800 text-white">
         <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-gray-400 text-sm">
-            {texts.layout.message.copyright}
-          </p>
+          <p className="text-center text-gray-400 text-sm">{copyrightText}</p>
         </div>
       </footer>
     </div>

--- a/pages/logout/index.js
+++ b/pages/logout/index.js
@@ -7,7 +7,7 @@ import { settings } from "config/settings.js";
 import { handleApiResponse } from "src/utils/handleApiResponse.js";
 import { texts } from "src/utils/texts.js";
 import PageLayout from "components/layouts/PageLayout";
-import LoadingSpinner from "components/ui/LoadingSpinner";
+import Spinner from "components/ui/Spinner";
 import Alert from "components/ui/Alert";
 import { useMessage } from "src/hooks/useMessage.js";
 
@@ -89,25 +89,24 @@ export default function Logout() {
 
   return (
     <PageLayout title={texts.logout.title} description="Saindo da sua conta">
-      {state.showContent && (
-        <div className="min-h-screen flex items-center justify-center bg-gray-50">
-          <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow-md">
-            {!error && (
-              <LoadingSpinner message={texts.logout.message.loading} />
-            )}
-            <Alert type="error" show={!!error}>
-              {error}
-            </Alert>
+      <div>
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          {texts.logout.title}
+        </h2>
+      </div>
 
-            <div className="text-center">
-              <h2 className="text-3xl font-extrabold text-gray-900">
-                {texts.logout.title}
-              </h2>
-              <p className="mt-2 text-sm text-gray-600">
-                {texts.logout.message.success}
+      {state.showContent && (
+        <div className="flex flex-col items-center space-y-4">
+          <Alert type="error">{error}</Alert>
+
+          {!error && (
+            <>
+              <Spinner size="10" />
+              <p className="text-sm text-gray-600">
+                {texts.logout.message.loading}
               </p>
-            </div>
-          </div>
+            </>
+          )}
         </div>
       )}
     </PageLayout>

--- a/src/utils/texts.js
+++ b/src/utils/texts.js
@@ -304,7 +304,7 @@ export const texts = {
   layout: {
     message: {
       loading: "Carregando...",
-      copyright: "© Lucas Cassin - 2025 - Todos os direitos reservados",
+      copyright: "© Lucas Cassin - {year} - Todos os direitos reservados",
     },
   },
   header: {

--- a/src/utils/texts.js
+++ b/src/utils/texts.js
@@ -152,6 +152,7 @@ export const texts = {
     loginLink: "Já tem uma conta? Faça login",
   },
   logout: {
+    title: "Sair",
     message: {
       loading: "Saindo...",
       success: "Sessão finalizada.",


### PR DESCRIPTION
## Summary
- Make the footer copyright year dynamic instead of hardcoded to 2025
- Round the password field's corners and align email/password input heights on login, register and password-reset screens
- Redesign the logout screen to match the login/register visual style (title, brand-colored spinner) instead of the previous generic white card
- Extend the default password expiration from 90 to 9999 days to stop unwanted forced password changes

## Test plan
- [ ] `npm run lint:prettier:check`
- [ ] `npm run lint:eslint:check`
- [ ] Manually verify login, register and password-reset screens (input corners/heights)
- [ ] Manually verify the logout screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zLh6QtAxbnFh2Pcf5u3AQ