### PR TITLE
refactor(pdv): payment pool + mobile UX pass

### DIFF
--- a/components/pdv/PaletteCard.js
+++ b/components/pdv/PaletteCard.js
@@ -10,13 +10,15 @@ const PaletteCard = React.memo(({ product, onClick }) => {
       type="button"
       onClick={() => onClick(product)}
       disabled={outOfStock}
-      className="flex flex-col items-start p-4 rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md hover:border-rakusai-purple transition-all text-left disabled:opacity-40 disabled:cursor-not-allowed"
+      className="flex flex-col items-start p-2 sm:p-4 rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md hover:border-rakusai-purple transition-all text-left disabled:opacity-40 disabled:cursor-not-allowed"
     >
-      <span className="font-semibold text-gray-900">{product.name}</span>
-      <span className="mt-1 text-lg font-bold text-rakusai-purple">
+      <span className="text-sm sm:text-base font-semibold text-gray-900 line-clamp-2">
+        {product.name}
+      </span>
+      <span className="mt-1 text-base sm:text-lg font-bold text-rakusai-purple">
         {formatCurrencyInCents(product.price_in_cents)}
       </span>
-      <span className="mt-1 text-xs text-gray-500">
+      <span className="mt-1 text-[11px] sm:text-xs text-gray-500">
         {outOfStock ? "Sem estoque" : `Estoque: ${product.stock_quantity}`}
       </span>
     </button>

--- a/components/pdv/PaymentEntryRow.js
+++ b/components/pdv/PaymentEntryRow.js
@@ -1,0 +1,112 @@
+import React from "react";
+import { FiTrash2 } from "react-icons/fi";
+import { FaCalculator } from "react-icons/fa";
+import { formatCurrencyInCents } from "src/utils/formatCurrencyInCents";
+
+const PaymentEntryRow = React.memo(
+  ({
+    methodName,
+    variantName,
+    amountInCents,
+    isEditable,
+    manualValue,
+    onAmountChange,
+    cashGivenValue,
+    onCashGivenChange,
+    calculatorOpen,
+    onToggleCalculator,
+    onRemove,
+  }) => {
+    const cashGivenInCents = cashGivenValue
+      ? Math.round(Number(cashGivenValue) * 100)
+      : null;
+    const change =
+      cashGivenInCents !== null
+        ? Math.max(0, cashGivenInCents - amountInCents)
+        : null;
+
+    return (
+      <div className="border border-gray-200 rounded-md p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p className="font-semibold text-sm text-gray-900">{methodName}</p>
+            {variantName && (
+              <p className="text-xs text-gray-500">{variantName}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="p-1.5 rounded-full bg-red-50 hover:bg-red-100 text-red-500 hover:text-red-700"
+            aria-label="Remover parcela"
+          >
+            <FiTrash2 size={16} />
+          </button>
+        </div>
+
+        <div className="mt-2">
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Valor
+          </label>
+          {isEditable ? (
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={
+                manualValue !== undefined
+                  ? manualValue
+                  : (amountInCents / 100).toFixed(2)
+              }
+              onChange={(e) => onAmountChange(e.target.value)}
+              className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-rakusai-purple focus:border-rakusai-purple"
+            />
+          ) : (
+            <p className="px-3 py-1.5 bg-gray-100 rounded-md text-sm font-semibold text-gray-700">
+              {formatCurrencyInCents(amountInCents)}{" "}
+              <span className="font-normal text-gray-400">(restante)</span>
+            </p>
+          )}
+        </div>
+
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={onToggleCalculator}
+            className="inline-flex items-center gap-2 text-xs font-medium text-rakusai-purple hover:text-rakusai-purple-light"
+            aria-expanded={calculatorOpen}
+          >
+            <FaCalculator className="h-3.5 w-3.5" />
+            Calculadora de troco
+          </button>
+
+          {calculatorOpen && (
+            <div className="mt-2 p-3 border border-gray-200 rounded-md bg-gray-50">
+              <label className="block text-xs font-medium text-gray-700 mb-1">
+                Valor recebido em dinheiro
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={cashGivenValue}
+                onChange={(e) => onCashGivenChange(e.target.value)}
+                placeholder="Ex: 50.00"
+                className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-rakusai-purple focus:border-rakusai-purple"
+              />
+              {change !== null && (
+                <p className="mt-2 text-sm font-semibold text-gray-800">
+                  Troco: {formatCurrencyInCents(change)}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+PaymentEntryRow.displayName = "PaymentEntryRow";
+
+export default PaymentEntryRow;

--- a/components/pdv/PaymentModal.js
+++ b/components/pdv/PaymentModal.js
@@ -1,8 +1,8 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { FiX } from "react-icons/fi";
-import { FaCalculator } from "react-icons/fa";
 import Button from "components/ui/Button";
 import Alert from "components/ui/Alert";
+import PaymentEntryRow from "components/pdv/PaymentEntryRow";
 import { formatCurrencyInCents } from "src/utils/formatCurrencyInCents";
 
 /**
@@ -24,15 +24,15 @@ function splitEvenly(ids, remainingInCents) {
 }
 
 /**
- * Calcula o valor de cada forma de pagamento selecionada: as que já foram
- * editadas manualmente mantêm o valor digitado; o restante do total é
- * dividido igualmente entre as que ainda não foram editadas.
+ * Calcula o valor de cada parcela do pool: as que já foram editadas
+ * manualmente mantêm o valor digitado; o restante do total é dividido
+ * igualmente entre as que ainda não foram editadas.
  */
-function computeAmounts(selectedIds, manualAmountsInCents, totalInCents) {
-  const manualIds = selectedIds.filter((id) =>
+function computeAmounts(entryIds, manualAmountsInCents, totalInCents) {
+  const manualIds = entryIds.filter((id) =>
     Object.prototype.hasOwnProperty.call(manualAmountsInCents, id),
   );
-  const autoIds = selectedIds.filter(
+  const autoIds = entryIds.filter(
     (id) => !Object.prototype.hasOwnProperty.call(manualAmountsInCents, id),
   );
 
@@ -56,11 +56,12 @@ export default function PaymentModal({
   onClose,
   onConfirm,
 }) {
-  const [selectedIds, setSelectedIds] = useState([]);
+  const nextLocalIdRef = useRef(0);
+  const [entries, setEntries] = useState([]);
   const [manualInputs, setManualInputs] = useState({});
-  const [variantByMethodId, setVariantByMethodId] = useState({});
   const [cashGivenInputs, setCashGivenInputs] = useState({});
   const [openCalculatorFor, setOpenCalculatorFor] = useState({});
+  const [expandedMethodId, setExpandedMethodId] = useState(null);
   const [notes, setNotes] = useState("");
 
   const methodsById = useMemo(
@@ -70,104 +71,123 @@ export default function PaymentModal({
 
   const manualAmountsInCents = useMemo(() => {
     const result = {};
-    for (const id of Object.keys(manualInputs)) {
-      const cents = Math.round(Number(manualInputs[id]) * 100);
-      result[id] = Number.isFinite(cents) ? cents : 0;
+    for (const localId of Object.keys(manualInputs)) {
+      const cents = Math.round(Number(manualInputs[localId]) * 100);
+      result[localId] = Number.isFinite(cents) ? cents : 0;
     }
     return result;
   }, [manualInputs]);
 
-  const { amounts, autoIds } = useMemo(
-    () => computeAmounts(selectedIds, manualAmountsInCents, totalInCents),
-    [selectedIds, manualAmountsInCents, totalInCents],
+  const entryIds = useMemo(
+    () => entries.map((entry) => String(entry.localId)),
+    [entries],
   );
 
-  const toggleMethod = (methodId) => {
-    setSelectedIds((prev) => {
-      const isSelected = prev.includes(methodId);
-      if (isSelected) {
-        setManualInputs((inputs) => {
-          const next = { ...inputs };
-          delete next[methodId];
-          return next;
-        });
-        setVariantByMethodId((variants) => {
-          const next = { ...variants };
-          delete next[methodId];
-          return next;
-        });
-        setCashGivenInputs((cash) => {
-          const next = { ...cash };
-          delete next[methodId];
-          return next;
-        });
-        setOpenCalculatorFor((open) => {
-          const next = { ...open };
-          delete next[methodId];
-          return next;
-        });
-        return prev.filter((id) => id !== methodId);
-      }
-      return [...prev, methodId];
-    });
-    // Selecionar/desselecionar uma forma redivide tudo igualmente de novo.
+  const { amounts, autoIds } = useMemo(
+    () => computeAmounts(entryIds, manualAmountsInCents, totalInCents),
+    [entryIds, manualAmountsInCents, totalInCents],
+  );
+
+  const addEntry = (methodId, variantId = null) => {
+    nextLocalIdRef.current += 1;
+    const localId = nextLocalIdRef.current;
+    setEntries((prev) => [...prev, { localId, methodId, variantId }]);
+    // Adicionar uma parcela redivide tudo igualmente de novo.
     setManualInputs({});
   };
 
-  const handleAmountChange = (methodId, value) => {
+  const removeEntry = (localId) => {
+    setEntries((prev) => prev.filter((entry) => entry.localId !== localId));
+    setManualInputs({});
+    setCashGivenInputs((prev) => {
+      const next = { ...prev };
+      delete next[localId];
+      return next;
+    });
+    setOpenCalculatorFor((prev) => {
+      const next = { ...prev };
+      delete next[localId];
+      return next;
+    });
+  };
+
+  const handleMethodClick = (method) => {
+    const activeVariants = method.variants.filter((v) => v.is_active);
+    if (activeVariants.length === 0) {
+      addEntry(method.id, null);
+      return;
+    }
+    setExpandedMethodId((prev) => (prev === method.id ? null : method.id));
+  };
+
+  const handleVariantClick = (methodId, variantId) => {
+    addEntry(methodId, variantId);
+  };
+
+  const handleAmountChange = (localId, value) => {
     if (value.trim() === "") {
       setManualInputs((prev) => {
         const next = { ...prev };
-        delete next[methodId];
+        delete next[localId];
         return next;
       });
       return;
     }
-    setManualInputs((prev) => ({ ...prev, [methodId]: value }));
+    setManualInputs((prev) => ({ ...prev, [localId]: value }));
   };
 
-  const sumAllocatedInCents = selectedIds.reduce(
+  const sumAllocatedInCents = entryIds.reduce(
     (acc, id) => acc + (amounts[id] || 0),
     0,
   );
   const sumMatchesTotal = sumAllocatedInCents === totalInCents;
+  const remainingInCents = Math.max(0, totalInCents - sumAllocatedInCents);
 
-  const variantsOk = selectedIds.every((id) => {
-    const method = methodsById[id];
-    const hasActiveVariants = method.variants.some((v) => v.is_active);
-    return !hasActiveVariants || Boolean(variantByMethodId[id]);
-  });
-
-  const cashGivenOk = selectedIds.every((id) => {
-    const raw = cashGivenInputs[id];
+  const cashGivenOk = entries.every((entry) => {
+    const raw = cashGivenInputs[entry.localId];
     if (!raw) return true;
     const cents = Math.round(Number(raw) * 100);
-    return Number.isFinite(cents) && cents >= amounts[id];
+    return Number.isFinite(cents) && cents >= amounts[String(entry.localId)];
   });
 
   const canConfirm =
-    selectedIds.length > 0 &&
-    sumMatchesTotal &&
-    variantsOk &&
-    cashGivenOk &&
-    !isSubmitting;
+    entries.length > 0 && sumMatchesTotal && cashGivenOk && !isSubmitting;
 
   const handleConfirm = () => {
     if (!canConfirm) return;
 
-    const payments = selectedIds.map((id) => {
-      const rawCashGiven = cashGivenInputs[id];
+    const groups = new Map();
+    for (const entry of entries) {
+      const key = `${entry.methodId}|${entry.variantId || ""}`;
+      const amountInCents = amounts[String(entry.localId)] || 0;
+      const rawCashGiven = cashGivenInputs[entry.localId];
       const cashGivenInCents = rawCashGiven
         ? Math.round(Number(rawCashGiven) * 100)
         : null;
 
-      return {
-        paymentMethodId: id,
-        paymentMethodVariantId: variantByMethodId[id] || null,
-        amountInCents: amounts[id],
-        cashGivenInCents,
-      };
-    });
+      const existing = groups.get(key);
+      if (existing) {
+        existing.amountInCents += amountInCents;
+        existing.cashGivenInCents += cashGivenInCents ?? amountInCents;
+        existing.hasCashGiven =
+          existing.hasCashGiven || cashGivenInCents !== null;
+      } else {
+        groups.set(key, {
+          paymentMethodId: entry.methodId,
+          paymentMethodVariantId: entry.variantId || null,
+          amountInCents,
+          cashGivenInCents: cashGivenInCents ?? amountInCents,
+          hasCashGiven: cashGivenInCents !== null,
+        });
+      }
+    }
+
+    const payments = Array.from(groups.values()).map((group) => ({
+      paymentMethodId: group.paymentMethodId,
+      paymentMethodVariantId: group.paymentMethodVariantId,
+      amountInCents: group.amountInCents,
+      cashGivenInCents: group.hasCashGiven ? group.cashGivenInCents : null,
+    }));
 
     onConfirm({ payments, notes: notes.trim() || undefined });
   };
@@ -195,156 +215,56 @@ export default function PaymentModal({
         )}
 
         <p className="text-sm text-gray-600 mb-2">
-          Selecione uma ou mais formas de pagamento para dividir a venda.
+          Toque em uma forma de pagamento para adicionar uma parcela à venda.
+          Toque quantas vezes for preciso para dividir em mais parcelas.
         </p>
 
-        <div className="flex flex-col gap-3 mb-4">
+        <div className="flex flex-col gap-2 mb-4">
           {paymentMethods.map((method) => {
-            const isSelected = selectedIds.includes(method.id);
-            const isManual = Object.prototype.hasOwnProperty.call(
-              manualInputs,
-              method.id,
-            );
-            const isEditable = isManual || autoIds.length > 1;
             const activeVariants = method.variants.filter((v) => v.is_active);
-            const amountInCents = amounts[method.id] || 0;
-            const cashGiven = cashGivenInputs[method.id] || "";
-            const cashGivenInCents = cashGiven
-              ? Math.round(Number(cashGiven) * 100)
-              : null;
-            const change =
-              cashGivenInCents !== null
-                ? Math.max(0, cashGivenInCents - amountInCents)
-                : null;
+            const isExpanded = expandedMethodId === method.id;
+            const countForMethod = entries.filter(
+              (entry) => entry.methodId === method.id,
+            ).length;
 
             return (
               <div
                 key={method.id}
                 className={`border rounded-md p-3 ${
-                  isSelected
+                  isExpanded
                     ? "border-rakusai-purple bg-rakusai-purple/5"
                     : "border-gray-200"
                 }`}
               >
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    onChange={() => toggleMethod(method.id)}
-                  />
+                <button
+                  type="button"
+                  onClick={() => handleMethodClick(method)}
+                  className="w-full flex items-center justify-between"
+                >
                   <span className="font-semibold text-sm text-gray-900">
                     {method.name}
                   </span>
-                </label>
+                  {countForMethod > 0 && (
+                    <span className="text-xs font-semibold bg-rakusai-purple/10 text-rakusai-purple rounded-full px-2 py-0.5">
+                      {countForMethod}x
+                    </span>
+                  )}
+                </button>
 
-                {isSelected && (
-                  <div className="mt-3 pl-6 flex flex-col gap-3">
-                    <div>
-                      <label className="block text-xs font-medium text-gray-700 mb-1">
-                        Valor
-                      </label>
-                      {isEditable ? (
-                        <input
-                          type="number"
-                          min="0"
-                          step="0.01"
-                          value={
-                            isManual
-                              ? manualInputs[method.id]
-                              : (amountInCents / 100).toFixed(2)
-                          }
-                          onChange={(e) =>
-                            handleAmountChange(method.id, e.target.value)
-                          }
-                          className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-rakusai-purple focus:border-rakusai-purple"
-                        />
-                      ) : (
-                        <p className="px-3 py-1.5 bg-gray-100 rounded-md text-sm font-semibold text-gray-700">
-                          {formatCurrencyInCents(amountInCents)}{" "}
-                          <span className="font-normal text-gray-400">
-                            (restante)
-                          </span>
-                        </p>
-                      )}
-                    </div>
-
-                    {activeVariants.length > 0 && (
-                      <div>
-                        <p className="text-xs font-medium text-gray-700 mb-1">
-                          Qual máquina/variante?
-                        </p>
-                        <div className="flex flex-wrap gap-2">
-                          {activeVariants.map((variant) => (
-                            <button
-                              key={variant.id}
-                              type="button"
-                              onClick={() =>
-                                setVariantByMethodId((prev) => ({
-                                  ...prev,
-                                  [method.id]: variant.id,
-                                }))
-                              }
-                              className={`py-1 px-3 rounded-full border text-xs font-semibold ${
-                                variantByMethodId[method.id] === variant.id
-                                  ? "bg-gray-800 text-white border-gray-800"
-                                  : "border-gray-300 text-gray-700"
-                              }`}
-                            >
-                              {variant.name}
-                            </button>
-                          ))}
-                        </div>
-                        {!variantByMethodId[method.id] && (
-                          <p className="mt-1 text-xs text-gray-500">
-                            Escolha uma variante para continuar.
-                          </p>
-                        )}
-                      </div>
-                    )}
-
-                    <div>
+                {activeVariants.length > 0 && isExpanded && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {activeVariants.map((variant) => (
                       <button
+                        key={variant.id}
                         type="button"
                         onClick={() =>
-                          setOpenCalculatorFor((prev) => ({
-                            ...prev,
-                            [method.id]: !prev[method.id],
-                          }))
+                          handleVariantClick(method.id, variant.id)
                         }
-                        className="inline-flex items-center gap-2 text-xs font-medium text-rakusai-purple hover:text-rakusai-purple-light"
-                        aria-expanded={Boolean(openCalculatorFor[method.id])}
+                        className="py-1 px-3 rounded-full border text-xs font-semibold border-gray-300 text-gray-700 hover:border-rakusai-purple hover:text-rakusai-purple"
                       >
-                        <FaCalculator className="h-3.5 w-3.5" />
-                        Calculadora de troco
+                        {variant.name}
                       </button>
-
-                      {openCalculatorFor[method.id] && (
-                        <div className="mt-2 p-3 border border-gray-200 rounded-md bg-gray-50">
-                          <label className="block text-xs font-medium text-gray-700 mb-1">
-                            Valor recebido em dinheiro
-                          </label>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={cashGiven}
-                            onChange={(e) =>
-                              setCashGivenInputs((prev) => ({
-                                ...prev,
-                                [method.id]: e.target.value,
-                              }))
-                            }
-                            placeholder="Ex: 50.00"
-                            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-rakusai-purple focus:border-rakusai-purple"
-                          />
-                          {change !== null && (
-                            <p className="mt-2 text-sm font-semibold text-gray-800">
-                              Troco: {formatCurrencyInCents(change)}
-                            </p>
-                          )}
-                        </div>
-                      )}
-                    </div>
+                    ))}
                   </div>
                 )}
               </div>
@@ -352,7 +272,67 @@ export default function PaymentModal({
           })}
         </div>
 
-        {selectedIds.length > 0 && !sumMatchesTotal && (
+        {entries.length > 0 && (
+          <div className="mb-4">
+            <div className="flex justify-between text-sm font-medium text-gray-700 mb-2">
+              <span>Alocado: {formatCurrencyInCents(sumAllocatedInCents)}</span>
+              <span
+                className={sumMatchesTotal ? "text-gray-700" : "text-red-600"}
+              >
+                Falta: {formatCurrencyInCents(remainingInCents)}
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              {entries.map((entry) => {
+                const method = methodsById[entry.methodId];
+                const variant = entry.variantId
+                  ? method.variants.find((v) => v.id === entry.variantId)
+                  : null;
+                const localIdKey = String(entry.localId);
+                const isManual = Object.prototype.hasOwnProperty.call(
+                  manualInputs,
+                  localIdKey,
+                );
+                const isEditable = isManual || autoIds.length > 1;
+                const amountInCents = amounts[localIdKey] || 0;
+
+                return (
+                  <PaymentEntryRow
+                    key={entry.localId}
+                    methodName={method.name}
+                    variantName={variant ? variant.name : null}
+                    amountInCents={amountInCents}
+                    isEditable={isEditable}
+                    manualValue={
+                      isManual ? manualInputs[localIdKey] : undefined
+                    }
+                    onAmountChange={(value) =>
+                      handleAmountChange(localIdKey, value)
+                    }
+                    cashGivenValue={cashGivenInputs[entry.localId] || ""}
+                    onCashGivenChange={(value) =>
+                      setCashGivenInputs((prev) => ({
+                        ...prev,
+                        [entry.localId]: value,
+                      }))
+                    }
+                    calculatorOpen={Boolean(openCalculatorFor[entry.localId])}
+                    onToggleCalculator={() =>
+                      setOpenCalculatorFor((prev) => ({
+                        ...prev,
+                        [entry.localId]: !prev[entry.localId],
+                      }))
+                    }
+                    onRemove={() => removeEntry(entry.localId)}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {entries.length > 0 && !sumMatchesTotal && (
           <Alert type="error">
             A soma dos valores ({formatCurrencyInCents(sumAllocatedInCents)})
             não bate com o total da venda ({formatCurrencyInCents(totalInCents)}

--- a/components/pdv/ProductPalette.js
+++ b/components/pdv/ProductPalette.js
@@ -22,7 +22,7 @@ export default function ProductPalette({ products, onAddItem }) {
         onChange={(e) => setSearch(e.target.value)}
         className="mb-4 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-rakusai-purple focus:border-rakusai-purple sm:text-sm"
       />
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 overflow-y-auto pr-1">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 sm:gap-3 overflow-y-auto pr-1">
         {filteredProducts.length === 0 && (
           <p className="col-span-full text-center text-gray-500 py-8">
             Nenhum produto encontrado.

--- a/components/pdv/admin/PaymentMethodManagement.js
+++ b/components/pdv/admin/PaymentMethodManagement.js
@@ -110,14 +110,14 @@ export default function PaymentMethodManagement({
                       {method.is_active ? "Ativa" : "Inativa"}
                     </span>
                   </div>
-                  <Button
-                    variant="danger"
-                    size="small"
-                    aria-label="Excluir"
+                  <button
+                    type="button"
                     onClick={() => setDeleteTarget({ type: "method", method })}
+                    className="p-2 rounded-full bg-red-600 hover:bg-red-700 text-white"
+                    aria-label="Excluir"
                   >
-                    <FiTrash2 />
-                  </Button>
+                    <FiTrash2 size={16} />
+                  </button>
                 </div>
               </div>
 
@@ -151,11 +151,11 @@ export default function PaymentMethodManagement({
               </div>
 
               {method.is_active && (
-                <div className="relative">
+                <div className="flex items-stretch border border-gray-300 rounded-md overflow-hidden">
                   <input
                     type="text"
                     placeholder="Nova variante (ex: Máquina Amarela)"
-                    className="w-full px-3 py-1.5 pr-9 border border-gray-300 rounded-md text-sm"
+                    className="flex-1 min-w-0 px-3 py-1.5 border-0 text-sm focus:outline-none"
                     value={newVariantNameByMethod[method.id] || ""}
                     onChange={(e) =>
                       setNewVariantNameByMethod((prev) => ({
@@ -170,16 +170,14 @@ export default function PaymentMethodManagement({
                       }
                     }}
                   />
-                  <div className="absolute inset-y-0 right-0 flex items-center pr-2">
-                    <button
-                      type="button"
-                      onClick={() => handleCreateVariant(method.id)}
-                      className="p-1 rounded-full text-gray-500 hover:text-rakusai-purple hover:bg-gray-100"
-                      aria-label="Adicionar variante"
-                    >
-                      <FiPlus size={16} />
-                    </button>
-                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleCreateVariant(method.id)}
+                    className="flex items-center justify-center px-4 border-l border-gray-300 bg-gray-50 hover:bg-gray-100 text-gray-600 hover:text-rakusai-purple"
+                    aria-label="Adicionar variante"
+                  >
+                    <FiPlus size={16} />
+                  </button>
                 </div>
               )}
             </div>

--- a/components/pdv/admin/PaymentMethodManagement.js
+++ b/components/pdv/admin/PaymentMethodManagement.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FiTrash2 } from "react-icons/fi";
+import { FiTrash2, FiPlus } from "react-icons/fi";
 import Button from "components/ui/Button";
 import FormInput from "components/forms/FormInput";
 import Switch from "components/ui/Switch";
@@ -117,7 +117,6 @@ export default function PaymentMethodManagement({
                     onClick={() => setDeleteTarget({ type: "method", method })}
                   >
                     <FiTrash2 />
-                    <span className="ml-2 sm:hidden">Excluir</span>
                   </Button>
                 </div>
               </div>
@@ -152,11 +151,11 @@ export default function PaymentMethodManagement({
               </div>
 
               {method.is_active && (
-                <div className="flex gap-2">
+                <div className="relative">
                   <input
                     type="text"
                     placeholder="Nova variante (ex: Máquina Amarela)"
-                    className="flex-1 px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+                    className="w-full px-3 py-1.5 pr-9 border border-gray-300 rounded-md text-sm"
                     value={newVariantNameByMethod[method.id] || ""}
                     onChange={(e) =>
                       setNewVariantNameByMethod((prev) => ({
@@ -164,14 +163,23 @@ export default function PaymentMethodManagement({
                         [method.id]: e.target.value,
                       }))
                     }
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleCreateVariant(method.id);
+                      }
+                    }}
                   />
-                  <Button
-                    variant="secondary"
-                    size="small"
-                    onClick={() => handleCreateVariant(method.id)}
-                  >
-                    + Variante
-                  </Button>
+                  <div className="absolute inset-y-0 right-0 flex items-center pr-2">
+                    <button
+                      type="button"
+                      onClick={() => handleCreateVariant(method.id)}
+                      className="p-1 rounded-full text-gray-500 hover:text-rakusai-purple hover:bg-gray-100"
+                      aria-label="Adicionar variante"
+                    >
+                      <FiPlus size={16} />
+                    </button>
+                  </div>
                 </div>
               )}
             </div>

--- a/components/pdv/admin/ProductManagement.js
+++ b/components/pdv/admin/ProductManagement.js
@@ -168,8 +168,13 @@ export default function ProductManagement({
             />
           </div>
         )}
-        <div className="flex flex-shrink-0 justify-end gap-2">
-          <Button type="submit" variant="primary" size="small" className="w-40">
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            className="w-full sm:w-40"
+          >
             {editingId ? "Salvar" : "+ Criar"}
           </Button>
           {editingId && (
@@ -177,6 +182,7 @@ export default function ProductManagement({
               type="button"
               variant="secondary"
               size="small"
+              className="w-full sm:w-40"
               onClick={resetForm}
             >
               Cancelar
@@ -187,110 +193,200 @@ export default function ProductManagement({
 
       {isLoading ? (
         <p className="text-center text-gray-500 py-8">Carregando...</p>
+      ) : products.length === 0 ? (
+        <p className="text-center text-gray-500 py-8">
+          Nenhum produto cadastrado.
+        </p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 text-sm">
-            <thead>
-              <tr className="text-gray-500">
-                <th className="py-2 pr-4 text-left">Nome</th>
-                <th className="py-2 pr-4 text-center">Preço</th>
-                <th className="py-2 pr-4 text-center">Piso Unitário</th>
-                <th className="py-2 pr-4 text-center">Estoque</th>
-                <th className="py-2 pr-4 text-center">Status</th>
-                <th className="py-2 pr-4 text-center">Ajustar estoque</th>
-                <th className="py-2 pr-4 text-center">Ações</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {products.map((product) => (
-                <tr key={product.id}>
-                  <td className="py-2 pr-4 font-medium text-left">
-                    {product.name}
-                  </td>
-                  <td className="py-2 pr-4 text-center">
-                    {formatCurrencyInCents(product.price_in_cents)}
-                  </td>
-                  <td className="py-2 pr-4 text-center">
-                    {formatCurrencyInCents(product.min_unit_price_in_cents)}
-                  </td>
-                  <td className="py-2 pr-4 text-center">
-                    {product.stock_quantity}
-                  </td>
-                  <td className="py-2 pr-4">
-                    <div className="flex items-center justify-center gap-2">
-                      <Switch
-                        checked={product.is_active}
-                        onChange={() => handleToggleActive(product)}
-                      />
-                      <span className="text-gray-700">
-                        {product.is_active ? "Ativo" : "Inativo"}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="py-2 pr-4">
-                    <div className="flex items-center justify-center gap-1.5">
-                      <input
-                        type="number"
-                        min="0"
-                        className="w-14 px-2 py-1 border border-gray-300 rounded-full text-sm text-center"
-                        value={stockDeltaByProduct[product.id] || ""}
-                        onChange={(e) =>
-                          setStockDeltaByProduct((prev) => ({
-                            ...prev,
-                            [product.id]: e.target.value,
-                          }))
-                        }
-                      />
-                      <button
-                        type="button"
-                        onClick={() => handleStockAdjust(product.id, 1)}
-                        className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
-                        aria-label="Adicionar ao estoque"
-                      >
-                        <FiPlus size={14} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleStockAdjust(product.id, -1)}
-                        className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
-                        aria-label="Remover do estoque"
-                      >
-                        <FiMinus size={14} />
-                      </button>
-                    </div>
-                  </td>
-                  <td className="py-2 pr-4">
-                    <div className="flex items-center justify-center gap-2">
-                      <Button
-                        variant="secondary"
-                        size="small"
-                        aria-label="Editar"
-                        onClick={() => startEdit(product)}
-                      >
-                        <FiEdit2 />
-                        <span className="ml-2 sm:hidden">Editar</span>
-                      </Button>
-                      <Button
-                        variant="danger"
-                        size="small"
-                        aria-label="Excluir"
-                        onClick={() => setDeleteTarget(product)}
-                      >
-                        <FiTrash2 />
-                        <span className="ml-2 sm:hidden">Excluir</span>
-                      </Button>
-                    </div>
-                  </td>
+        <>
+          <div className="hidden md:block overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead>
+                <tr className="text-gray-500">
+                  <th className="py-2 pr-4 text-left">Nome</th>
+                  <th className="py-2 pr-4 text-center">Preço</th>
+                  <th className="py-2 pr-4 text-center">Piso Unitário</th>
+                  <th className="py-2 pr-4 text-center">Estoque</th>
+                  <th className="py-2 pr-4 text-center">Status</th>
+                  <th className="py-2 pr-4 text-center">Ajustar estoque</th>
+                  <th className="py-2 pr-4 text-center">Ações</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-          {products.length === 0 && (
-            <p className="text-center text-gray-500 py-8">
-              Nenhum produto cadastrado.
-            </p>
-          )}
-        </div>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {products.map((product) => (
+                  <tr key={product.id}>
+                    <td className="py-2 pr-4 font-medium text-left">
+                      {product.name}
+                    </td>
+                    <td className="py-2 pr-4 text-center">
+                      {formatCurrencyInCents(product.price_in_cents)}
+                    </td>
+                    <td className="py-2 pr-4 text-center">
+                      {formatCurrencyInCents(product.min_unit_price_in_cents)}
+                    </td>
+                    <td className="py-2 pr-4 text-center">
+                      {product.stock_quantity}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <div className="flex items-center justify-center gap-2">
+                        <Switch
+                          checked={product.is_active}
+                          onChange={() => handleToggleActive(product)}
+                        />
+                        <span className="text-gray-700">
+                          {product.is_active ? "Ativo" : "Inativo"}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <div className="flex items-center justify-center gap-1.5">
+                        <input
+                          type="number"
+                          min="0"
+                          className="w-14 px-2 py-1 border border-gray-300 rounded-full text-sm text-center"
+                          value={stockDeltaByProduct[product.id] || ""}
+                          onChange={(e) =>
+                            setStockDeltaByProduct((prev) => ({
+                              ...prev,
+                              [product.id]: e.target.value,
+                            }))
+                          }
+                        />
+                        <button
+                          type="button"
+                          onClick={() => handleStockAdjust(product.id, 1)}
+                          className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                          aria-label="Adicionar ao estoque"
+                        >
+                          <FiPlus size={14} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleStockAdjust(product.id, -1)}
+                          className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                          aria-label="Remover do estoque"
+                        >
+                          <FiMinus size={14} />
+                        </button>
+                      </div>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <div className="flex items-center justify-center gap-2">
+                        <Button
+                          variant="secondary"
+                          size="small"
+                          aria-label="Editar"
+                          onClick={() => startEdit(product)}
+                        >
+                          <FiEdit2 />
+                          <span className="ml-2 sm:hidden">Editar</span>
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="small"
+                          aria-label="Excluir"
+                          onClick={() => setDeleteTarget(product)}
+                        >
+                          <FiTrash2 />
+                          <span className="ml-2 sm:hidden">Excluir</span>
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="md:hidden space-y-3">
+            {products.map((product) => (
+              <div
+                key={product.id}
+                className="border border-gray-200 rounded-lg p-4"
+              >
+                <div className="flex items-start justify-between gap-2 mb-3">
+                  <div>
+                    <p className="font-semibold text-gray-900">
+                      {product.name}
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      {formatCurrencyInCents(product.price_in_cents)} · piso{" "}
+                      {formatCurrencyInCents(product.min_unit_price_in_cents)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Switch
+                      checked={product.is_active}
+                      onChange={() => handleToggleActive(product)}
+                    />
+                    <span className="text-sm text-gray-700">
+                      {product.is_active ? "Ativo" : "Inativo"}
+                    </span>
+                  </div>
+                </div>
+
+                <p className="text-sm text-gray-700 mb-3">
+                  Estoque:{" "}
+                  <span className="font-semibold">
+                    {product.stock_quantity}
+                  </span>
+                </p>
+
+                <div className="flex items-center gap-1.5 mb-3">
+                  <input
+                    type="number"
+                    min="0"
+                    className="w-14 px-2 py-1 border border-gray-300 rounded-full text-sm text-center"
+                    value={stockDeltaByProduct[product.id] || ""}
+                    onChange={(e) =>
+                      setStockDeltaByProduct((prev) => ({
+                        ...prev,
+                        [product.id]: e.target.value,
+                      }))
+                    }
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleStockAdjust(product.id, 1)}
+                    className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                    aria-label="Adicionar ao estoque"
+                  >
+                    <FiPlus size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleStockAdjust(product.id, -1)}
+                    className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                    aria-label="Remover do estoque"
+                  >
+                    <FiMinus size={14} />
+                  </button>
+                </div>
+
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    className="flex-1"
+                    onClick={() => startEdit(product)}
+                  >
+                    <FiEdit2 />
+                    <span className="ml-2">Editar</span>
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="small"
+                    className="flex-1"
+                    onClick={() => setDeleteTarget(product)}
+                  >
+                    <FiTrash2 />
+                    <span className="ml-2">Excluir</span>
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
       )}
 
       {deleteTarget && (

--- a/components/pdv/admin/ProductManagement.js
+++ b/components/pdv/admin/ProductManagement.js
@@ -325,42 +325,44 @@ export default function ProductManagement({
                   </div>
                 </div>
 
-                <p className="text-sm text-gray-700 mb-3">
-                  Estoque:{" "}
-                  <span className="font-semibold">
-                    {product.stock_quantity}
-                  </span>
-                </p>
+                <div className="flex items-center justify-between gap-2 mb-3">
+                  <p className="text-sm text-gray-700">
+                    Estoque:{" "}
+                    <span className="font-semibold">
+                      {product.stock_quantity}
+                    </span>
+                  </p>
 
-                <div className="flex items-center gap-1.5 mb-3">
-                  <input
-                    type="number"
-                    min="0"
-                    className="w-14 px-2 py-1 border border-gray-300 rounded-full text-sm text-center"
-                    value={stockDeltaByProduct[product.id] || ""}
-                    onChange={(e) =>
-                      setStockDeltaByProduct((prev) => ({
-                        ...prev,
-                        [product.id]: e.target.value,
-                      }))
-                    }
-                  />
-                  <button
-                    type="button"
-                    onClick={() => handleStockAdjust(product.id, 1)}
-                    className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
-                    aria-label="Adicionar ao estoque"
-                  >
-                    <FiPlus size={14} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleStockAdjust(product.id, -1)}
-                    className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
-                    aria-label="Remover do estoque"
-                  >
-                    <FiMinus size={14} />
-                  </button>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <input
+                      type="number"
+                      min="0"
+                      className="w-14 px-2 py-1 border border-gray-300 rounded-full text-sm text-center"
+                      value={stockDeltaByProduct[product.id] || ""}
+                      onChange={(e) =>
+                        setStockDeltaByProduct((prev) => ({
+                          ...prev,
+                          [product.id]: e.target.value,
+                        }))
+                      }
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleStockAdjust(product.id, 1)}
+                      className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                      aria-label="Adicionar ao estoque"
+                    >
+                      <FiPlus size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleStockAdjust(product.id, -1)}
+                      className="p-1.5 rounded-full bg-gray-100 hover:bg-gray-200 text-gray-700"
+                      aria-label="Remover do estoque"
+                    >
+                      <FiMinus size={14} />
+                    </button>
+                  </div>
                 </div>
 
                 <div className="flex gap-2">

--- a/components/pdv/admin/SalesReport.js
+++ b/components/pdv/admin/SalesReport.js
@@ -77,6 +77,20 @@ export default function SalesReport({
     if (result) onFetch(buildReportQuery());
   };
 
+  const formatSalePayments = (sale) =>
+    sale.payments
+      .map(
+        (payment) =>
+          `${payment.payment_method_name_snapshot}` +
+          (payment.payment_method_variant_name_snapshot
+            ? ` (${payment.payment_method_variant_name_snapshot})`
+            : "") +
+          (sale.payments.length > 1
+            ? ` — ${formatCurrencyInCents(payment.amount_in_cents)}`
+            : ""),
+      )
+      .join(" + ");
+
   // As variantes já pertencem a uma única forma de pagamento, mas o mesmo
   // nome de variante pode se repetir em formas diferentes (ex: duas formas
   // com uma variante "Balcão") — este gráfico soma essas ocorrências.
@@ -153,7 +167,7 @@ export default function SalesReport({
             emptyLabel="Nenhum produto cadastrado."
           />
         </div>
-        <div className="flex flex-shrink-0 flex-col items-end gap-2">
+        <div className="flex flex-col items-stretch sm:items-end gap-2 w-full sm:w-auto">
           <label className="inline-flex items-center gap-2 text-sm text-gray-700">
             <input
               type="checkbox"
@@ -163,7 +177,12 @@ export default function SalesReport({
             />
             Incluir canceladas
           </label>
-          <Button type="submit" variant="primary" size="small" className="w-40">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            className="w-full sm:w-40"
+          >
             Filtrar
           </Button>
         </div>
@@ -248,34 +267,57 @@ export default function SalesReport({
               Analítico
             </h4>
 
-            <div className="overflow-x-auto mb-8">
+            <div className="mb-8">
               <h5 className="text-sm font-semibold text-gray-700 mb-2">
                 Produtos vendidos
               </h5>
-              <table className="min-w-full divide-y divide-gray-200 text-sm">
-                <thead>
-                  <tr className="text-gray-500">
-                    <th className="py-2 pr-4 text-left">Produto</th>
-                    <th className="py-2 pr-4 text-center">Quantidade</th>
-                    <th className="py-2 pr-4 text-center">Faturamento</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {report.by_product.map((row) => (
-                    <tr key={row.product_id}>
-                      <td className="py-2 pr-4 text-left">
-                        {row.product_name}
-                      </td>
-                      <td className="py-2 pr-4 text-center">
-                        {row.quantity_sold}
-                      </td>
-                      <td className="py-2 pr-4 text-center">
-                        {formatCurrencyInCents(row.revenue_in_cents)}
-                      </td>
+
+              <div className="hidden md:block overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead>
+                    <tr className="text-gray-500">
+                      <th className="py-2 pr-4 text-left">Produto</th>
+                      <th className="py-2 pr-4 text-center">Quantidade</th>
+                      <th className="py-2 pr-4 text-center">Faturamento</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {report.by_product.map((row) => (
+                      <tr key={row.product_id}>
+                        <td className="py-2 pr-4 text-left">
+                          {row.product_name}
+                        </td>
+                        <td className="py-2 pr-4 text-center">
+                          {row.quantity_sold}
+                        </td>
+                        <td className="py-2 pr-4 text-center">
+                          {formatCurrencyInCents(row.revenue_in_cents)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="md:hidden divide-y divide-gray-100">
+                {report.by_product.map((row) => (
+                  <div
+                    key={row.product_id}
+                    className="py-2 flex items-center justify-between gap-2 text-sm"
+                  >
+                    <div>
+                      <p className="font-medium text-gray-900">
+                        {row.product_name}
+                      </p>
+                      <p className="text-gray-500">Qtd: {row.quantity_sold}</p>
+                    </div>
+                    <p className="font-semibold text-gray-900">
+                      {formatCurrencyInCents(row.revenue_in_cents)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
               {report.by_product.length === 0 && (
                 <p className="text-center text-gray-500 py-8">
                   Nenhum produto vendido para os filtros selecionados.
@@ -283,86 +325,135 @@ export default function SalesReport({
               )}
             </div>
 
-            <div className="overflow-x-auto">
+            <div>
               <h5 className="text-sm font-semibold text-gray-700 mb-2">
                 Vendas
               </h5>
-              <table className="min-w-full divide-y divide-gray-200 text-sm">
-                <thead>
-                  <tr className="text-gray-500">
-                    <th className="py-2 pr-4 text-center">Nº</th>
-                    <th className="py-2 pr-4 text-center">Data</th>
-                    <th className="py-2 pr-4 text-left">Forma</th>
-                    <th className="py-2 pr-4 text-center">Total</th>
-                    <th className="py-2 pr-4 text-center">Status</th>
-                    {canCancel && (
-                      <th className="py-2 pr-4 text-center">Ações</th>
-                    )}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {report.sales.map((sale) => (
-                    <tr key={sale.id}>
-                      <td className="py-2 pr-4 text-center">
+
+              <div className="hidden md:block overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead>
+                    <tr className="text-gray-500">
+                      <th className="py-2 pr-4 text-center">Nº</th>
+                      <th className="py-2 pr-4 text-center">Data</th>
+                      <th className="py-2 pr-4 text-left">Forma</th>
+                      <th className="py-2 pr-4 text-center">Total</th>
+                      <th className="py-2 pr-4 text-center">Status</th>
+                      {canCancel && (
+                        <th className="py-2 pr-4 text-center">Ações</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {report.sales.map((sale) => (
+                      <tr key={sale.id}>
+                        <td className="py-2 pr-4 text-center">
+                          #{sale.sale_number}
+                        </td>
+                        <td className="py-2 pr-4 text-center">
+                          {new Date(sale.created_at).toLocaleString("pt-BR")}
+                        </td>
+                        <td className="py-2 pr-4 text-left">
+                          {formatSalePayments(sale)}
+                        </td>
+                        <td className="py-2 pr-4 text-center">
+                          {formatCurrencyInCents(sale.total_in_cents)}
+                        </td>
+                        <td className="py-2 pr-4 text-center">
+                          {sale.status === "completed"
+                            ? "Concluída"
+                            : "Cancelada"}
+                        </td>
+                        {canCancel && (
+                          <td className="py-2 pr-4">
+                            {sale.status === "completed" && (
+                              <div className="flex items-center justify-center gap-2">
+                                <Button
+                                  variant={
+                                    pendingCancelSaleId === sale.id
+                                      ? "warning"
+                                      : "danger"
+                                  }
+                                  size="small"
+                                  onClick={() => handleCancel(sale.id)}
+                                  disabled={
+                                    cancellingSaleId === sale.id ||
+                                    (pendingCancelSaleId &&
+                                      pendingCancelSaleId !== sale.id)
+                                  }
+                                >
+                                  {cancellingSaleId === sale.id
+                                    ? "Cancelando..."
+                                    : pendingCancelSaleId === sale.id
+                                      ? "Certeza?"
+                                      : "Cancelar"}
+                                </Button>
+                              </div>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="md:hidden space-y-3">
+                {report.sales.map((sale) => (
+                  <div
+                    key={sale.id}
+                    className="border border-gray-200 rounded-lg p-3 text-sm"
+                  >
+                    <div className="flex justify-between items-start mb-1">
+                      <span className="font-semibold text-gray-900">
                         #{sale.sale_number}
-                      </td>
-                      <td className="py-2 pr-4 text-center">
-                        {new Date(sale.created_at).toLocaleString("pt-BR")}
-                      </td>
-                      <td className="py-2 pr-4 text-left">
-                        {sale.payments
-                          .map(
-                            (payment) =>
-                              `${payment.payment_method_name_snapshot}` +
-                              (payment.payment_method_variant_name_snapshot
-                                ? ` (${payment.payment_method_variant_name_snapshot})`
-                                : "") +
-                              (sale.payments.length > 1
-                                ? ` — ${formatCurrencyInCents(payment.amount_in_cents)}`
-                                : ""),
-                          )
-                          .join(" + ")}
-                      </td>
-                      <td className="py-2 pr-4 text-center">
-                        {formatCurrencyInCents(sale.total_in_cents)}
-                      </td>
-                      <td className="py-2 pr-4 text-center">
+                      </span>
+                      <span
+                        className={
+                          sale.status === "completed"
+                            ? "text-green-700"
+                            : "text-red-600"
+                        }
+                      >
                         {sale.status === "completed"
                           ? "Concluída"
                           : "Cancelada"}
-                      </td>
-                      {canCancel && (
-                        <td className="py-2 pr-4">
-                          {sale.status === "completed" && (
-                            <div className="flex items-center justify-center gap-2">
-                              <Button
-                                variant={
-                                  pendingCancelSaleId === sale.id
-                                    ? "warning"
-                                    : "danger"
-                                }
-                                size="small"
-                                onClick={() => handleCancel(sale.id)}
-                                disabled={
-                                  cancellingSaleId === sale.id ||
-                                  (pendingCancelSaleId &&
-                                    pendingCancelSaleId !== sale.id)
-                                }
-                              >
-                                {cancellingSaleId === sale.id
-                                  ? "Cancelando..."
-                                  : pendingCancelSaleId === sale.id
-                                    ? "Certeza?"
-                                    : "Cancelar"}
-                              </Button>
-                            </div>
-                          )}
-                        </td>
-                      )}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+                      </span>
+                    </div>
+                    <p className="text-gray-500 mb-1">
+                      {new Date(sale.created_at).toLocaleString("pt-BR")}
+                    </p>
+                    <p className="text-gray-700 mb-1">
+                      {formatSalePayments(sale)}
+                    </p>
+                    <p className="font-bold text-gray-900 mb-2">
+                      {formatCurrencyInCents(sale.total_in_cents)}
+                    </p>
+                    {canCancel && sale.status === "completed" && (
+                      <Button
+                        variant={
+                          pendingCancelSaleId === sale.id ? "warning" : "danger"
+                        }
+                        size="small"
+                        className="w-full"
+                        onClick={() => handleCancel(sale.id)}
+                        disabled={
+                          cancellingSaleId === sale.id ||
+                          (pendingCancelSaleId &&
+                            pendingCancelSaleId !== sale.id)
+                        }
+                      >
+                        {cancellingSaleId === sale.id
+                          ? "Cancelando..."
+                          : pendingCancelSaleId === sale.id
+                            ? "Certeza?"
+                            : "Cancelar"}
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+
               {report.sales.length === 0 && (
                 <p className="text-center text-gray-500 py-8">
                   Nenhuma venda encontrada para os filtros selecionados.

--- a/components/pdv/admin/SettingsForm.js
+++ b/components/pdv/admin/SettingsForm.js
@@ -119,9 +119,9 @@ export default function SettingsForm({ pdvSettings, isLoading, onUpdate }) {
             onChange={handleChange}
           />
         </div>
-        <div className="flex flex-shrink-0 justify-end">
+        <div className="w-full sm:w-auto">
           {justSaved ? (
-            <div className="w-40 flex items-center justify-center gap-1 py-2 px-6 text-sm font-semibold text-green-700 bg-green-50 border border-green-200 rounded-full">
+            <div className="w-full sm:w-40 flex items-center justify-center gap-1 py-2 px-6 text-sm font-semibold text-green-700 bg-green-50 border border-green-200 rounded-full">
               <FiCheckCircle /> Salvo!
             </div>
           ) : (
@@ -129,7 +129,7 @@ export default function SettingsForm({ pdvSettings, isLoading, onUpdate }) {
               type="submit"
               variant="primary"
               size="small"
-              className="w-40"
+              className="w-full sm:w-40"
             >
               Salvar
             </Button>

--- a/pages/pdv/index.js
+++ b/pages/pdv/index.js
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react";
+import { FiX } from "react-icons/fi";
 import { useAuth } from "src/contexts/AuthContext.js";
 import PageLayout from "components/layouts/PageLayout";
 import Loading from "components/Loading.js";
 import Alert from "components/ui/Alert";
+import Button from "components/ui/Button";
 import ProductPalette from "components/pdv/ProductPalette";
 import Cart from "components/pdv/Cart";
 import DiscountModal from "components/pdv/DiscountModal";
@@ -19,6 +21,7 @@ export default function PdvCashierPage() {
   const cashier = usePdvCashier();
 
   const [checkoutStep, setCheckoutStep] = useState(null); // null | "discount" | "payment"
+  const [isCartModalOpen, setIsCartModalOpen] = useState(false);
   const [lastSaleMessage, setLastSaleMessage] = useState(null);
 
   // A mensagem de venda concluída some sozinha após alguns segundos.
@@ -72,6 +75,7 @@ export default function PdvCashierPage() {
 
   const handleCheckout = () => {
     setLastSaleMessage(null);
+    setIsCartModalOpen(false);
     setCheckoutStep("discount");
   };
 
@@ -85,6 +89,7 @@ export default function PdvCashierPage() {
 
     if (data) {
       setCheckoutStep(null);
+      setIsCartModalOpen(false);
       setLastSaleMessage(
         `Venda #${data.sale_number} concluída — Total ${formatCurrencyInCents(data.total_in_cents)}`,
       );
@@ -116,14 +121,14 @@ export default function PdvCashierPage() {
       {cashier.isLoadingCatalog ? (
         <Loading message="Carregando catálogo..." />
       ) : (
-        <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 h-[65vh]">
+        <div className="mt-6 pb-24 lg:pb-0 grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 lg:h-[65vh]">
             <ProductPalette
               products={cashier.products}
               onAddItem={cashier.addItem}
             />
           </div>
-          <div className="lg:col-span-1 h-[65vh]">
+          <div className="hidden lg:block lg:col-span-1 h-[65vh]">
             <Cart
               items={cashier.cartItems}
               subtotalInCents={cashier.subtotalInCents}
@@ -132,6 +137,53 @@ export default function PdvCashierPage() {
               onRemove={cashier.removeItem}
               onCheckout={handleCheckout}
             />
+          </div>
+        </div>
+      )}
+
+      {cashier.cartItems.length > 0 && (
+        <div className="lg:hidden fixed bottom-0 inset-x-0 z-40 bg-white border-t border-gray-200 shadow-[0_-2px_8px_rgba(0,0,0,0.08)] p-3 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs text-gray-500">
+              {cashier.cartItems.length}{" "}
+              {cashier.cartItems.length === 1 ? "item" : "itens"}
+            </p>
+            <p className="text-lg font-bold text-gray-900">
+              {formatCurrencyInCents(cashier.subtotalInCents)}
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={() => setIsCartModalOpen(true)}
+          >
+            Ver Carrinho
+          </Button>
+        </div>
+      )}
+
+      {isCartModalOpen && (
+        <div
+          className="lg:hidden fixed inset-0 z-[60] flex items-end justify-center bg-black bg-opacity-50 p-0"
+          style={{ margin: 0 }}
+        >
+          <div className="bg-white rounded-t-lg w-full h-[85vh] flex flex-col">
+            <div className="flex justify-between items-center p-4 border-b border-gray-200">
+              <h3 className="text-lg font-bold text-gray-900">Carrinho</h3>
+              <button onClick={() => setIsCartModalOpen(false)}>
+                <FiX className="h-6 w-6 text-gray-500" />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 p-4">
+              <Cart
+                items={cashier.cartItems}
+                subtotalInCents={cashier.subtotalInCents}
+                onIncrement={cashier.incrementItem}
+                onDecrement={cashier.decrementItem}
+                onRemove={cashier.removeItem}
+                onCheckout={handleCheckout}
+              />
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Payment methods in a sale now work as a pool: the cashier can click a method (+ variant) as many times as needed to add split entries, tracks allocated/remaining live, and identical method+variant entries are merged into a single row before hitting the sale API (no backend changes needed).
- Cashier screen: on mobile, the cart moved off the bottom-of-page position into a fixed bar (item count + subtotal + "Ver Carrinho") that opens the cart in a full-screen modal; desktop layout is unchanged. Product cards are also more compact on mobile (smaller padding/fonts, 2-line name clamp).
- PDV admin screens: action-button rows (Product, Settings, Sales Report forms) now go full-width on mobile instead of leaving empty space; the Product and Sales tables render as stacked cards below `md:`; the payment-method "Excluir" button is a round icon button and "+ Variante" is now an inline addon inside its input (same pattern as the password-generator button).

## Test plan
- [x] `npm run lint:prettier:check` / `npm run lint:eslint:check`
- [x] Manual browser verification (real Postgres + Next dev server, headless Chromium) for every change: split/merge payment entries end-to-end against the real sale API, mobile cart bar + modal flow through to a confirmed sale, admin button/table responsiveness at 375px and 1440px viewports, payment-method delete/add-variant restyle with a real variant creation request.
- [x] Manual pass on a real device recommended before merging, since all verification above was done via headless Chromium at fixed viewport sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU3vyooUuw7ejpNCkwTpmt